### PR TITLE
issue label 자동화 기능 추가

### DIFF
--- a/.github/workflows/issues-labeler.yml
+++ b/.github/workflows/issues-labeler.yml
@@ -1,0 +1,37 @@
+# workflow 의 이름
+name: issues labeler
+
+# 트리거될 이벤트 설정
+on:
+  issue_comment:
+    types: [created]
+
+# 트리거되었을 때 실행될 job 작성
+jobs:
+  issue_commented:
+    if: github.event.comment.user.login == 'Ryan-Dia'||'SWARVY'||'Bori-github'||'limvik'||'hannaax'||'BaxDailyGit'
+    name: apply-label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Label
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const userLabelMap = {
+              'Ryan-Dia': '철원',
+              'SWARVY': '현호',
+              'Bori-github': '보리',
+              'limvik': '성국',
+              'hannaax': '한나',
+              'BaxDailyGit': '승진'
+            };
+            const userLogin = context.payload.comment.user.login;
+            const labelToAdd = userLabelMap[userLogin];
+
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: [`${labelToAdd}`]
+            });


### PR DESCRIPTION
# what
- issue label 자동화

# why
- role이 `Member` 이면  댓글 작성(제출) 후 `Labels`을 설정할 수 없음

<img width="237" alt="image" src="https://github.com/Gamangjum-lihou/study-log-archive/assets/76567238/3b2e328a-3cd2-44d2-b319-3b50903b6a20">


# how
- github action으로 자동화